### PR TITLE
공지 RESTful API의 페이지단위 읽기 요청에 쿼리 조건 넣는 기능 추가

### DIFF
--- a/src/main/java/team1/mini2/dz3/controller/api/NoticeApiController.java
+++ b/src/main/java/team1/mini2/dz3/controller/api/NoticeApiController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import team1.mini2.dz3.model.NoticeDto;
@@ -25,7 +26,17 @@ public class NoticeApiController {
 	private NoticeServiceImpl noticeService;
 
 	@GetMapping("/page/{pNum}")
-	public List<NoticeDto> getList(@PathVariable(required=true) int pNum){
+	public List<NoticeDto> getList(@PathVariable(required=true) int pNum, @RequestParam(required=false) String opt, @RequestParam(required=false) String key){
+		if(opt!=null&&key!=null) {
+			switch(opt) {
+			case "noticeTitle":
+				return noticeService.getNoticePageWithTitle(pNum, key);
+			case "noticeContent":
+				return noticeService.getNoticePageWithContent(pNum, key);
+			case "noticeRegDate":
+				return noticeService.getNoticePageWithRegDate(pNum, key);
+			}
+		}
 		return noticeService.getNoticePage(pNum);
 	}
 	

--- a/src/main/java/team1/mini2/dz3/model/NoticeDao.java
+++ b/src/main/java/team1/mini2/dz3/model/NoticeDao.java
@@ -4,7 +4,10 @@ import java.util.Map;
 import java.util.List;
 
 public interface NoticeDao {
-	List<NoticeDto> getList(Map<String, Integer> map);
+	List<NoticeDto> getList(Map<String, String> map);
+	List<NoticeDto> getListWithTitle(Map<String, String> map);
+	List<NoticeDto> getListWithContent(Map<String, String> map);
+	List<NoticeDto> getListWithRegDate(Map<String, String> map);
 	NoticeDto get(int noticeNo);
 	int getCount();
 	void add(Map<String, String> map);

--- a/src/main/java/team1/mini2/dz3/service/NoticeService.java
+++ b/src/main/java/team1/mini2/dz3/service/NoticeService.java
@@ -7,6 +7,9 @@ import team1.mini2.dz3.model.NoticeDto;
 
 public interface NoticeService {
 	List<NoticeDto> getNoticePage(int page);
+	List<NoticeDto> getNoticePageWithTitle(int page, String key);
+	List<NoticeDto> getNoticePageWithContent(int page, String key);
+	List<NoticeDto> getNoticePageWithRegDate(int page, String key);
 	NoticeDto getNotice(int noticeNo);
 	void addNotice(Map<String, String> map);
 	void removeNotice(int noticeNo);

--- a/src/main/java/team1/mini2/dz3/service/NoticeServiceImpl.java
+++ b/src/main/java/team1/mini2/dz3/service/NoticeServiceImpl.java
@@ -19,21 +19,37 @@ public class NoticeServiceImpl implements NoticeService {
 	
 	@Override
 	public List<NoticeDto> getNoticePage(int page) {
-		if(page<=0) {//페이지가 0보다 같거나 작을순 없음.
-			return null;
-		}
-		NoticeDao dao = sqlSession.getMapper(NoticeDao.class);
+		return sqlSession.getMapper(NoticeDao.class).getList(getPageMap(page));
+	}
+	
+	@Override
+	public List<NoticeDto> getNoticePageWithTitle(int page, String key){
+		Map<String, String> map = getPageMap(page);
+		map.put("key", key);
+		return sqlSession.getMapper(NoticeDao.class).getListWithTitle(map);
+	}
+	@Override
+	public List<NoticeDto> getNoticePageWithContent(int page, String key){
+		Map<String, String> map = getPageMap(page);
+		map.put("key", key);
+		return sqlSession.getMapper(NoticeDao.class).getListWithContent(map);
+	}
+	@Override
+	public List<NoticeDto> getNoticePageWithRegDate(int page, String key){
+		Map<String, String> map = getPageMap(page);
+		map.put("key", key);
+		return sqlSession.getMapper(NoticeDao.class).getListWithRegDate(map);
+	}
+	
+	
+	public Map<String, String> getPageMap(int page) {
 		int rowSize = 10;
-		int cnt = dao.getCount();
 		int start = (page*rowSize)-(rowSize -1);
-		int end = Math.max(cnt, page*rowSize);
-		if(start>cnt) {//시작 행 번호가 행 개수보다 크면 해당 페이지 없음.
-			return null;
-		}
-		HashMap<String, Integer> map = new HashMap<>();
-		map.put("start", start);
-		map.put("end", end);
-		return dao.getList(map);
+		int end = page*rowSize;
+		HashMap<String, String> map = new HashMap<>();
+		map.put("start", Integer.toString(start));
+		map.put("end", Integer.toString(end));
+		return map;
 	}
 	
 	@Override

--- a/src/main/resources/mybatis/mappers/notice-mapper.xml
+++ b/src/main/resources/mybatis/mappers/notice-mapper.xml
@@ -5,8 +5,8 @@
 <mapper namespace="team1.mini2.dz3.model.NoticeDao">
 
 	<resultMap id="noticeMap" type="NoticeDto">
-		<result property="noticeNo" column="notice_no" javaType="java.lang.Integer"
-			jdbcType="INTEGER" />
+		<result property="noticeNo" column="notice_no"
+			javaType="java.lang.Integer" jdbcType="INTEGER" />
 		<result property="noticeTitle" column="notice_title"
 			javaType="java.lang.String" jdbcType="VARCHAR" />
 		<result property="noticeContent" column="notice_content"
@@ -14,34 +14,74 @@
 		<result property="noticeRegDate" column="notice_regdate"
 			javaType="java.util.Date" jdbcType="DATE" />
 	</resultMap>
-	
+
 	<select id="getList" parameterType="map" resultMap="noticeMap">
 		select *
-		from (select A.*, ROWNUM r from
+		from
+		(select A.*, ROWNUM r from
 		(select * from notice
 		order by notice_no) A
 		)
 		where r >= #{start} and r &lt;= #{end}
 	</select>
-    
-    <select id="get" parameterType="int" resultMap="noticeMap">
-        select * from notice where notice_no = #{noticeNo}
-    </select>
+
+	<select id="getListWithTitle" parameterType="map"
+		resultMap="noticeMap">
+		select *
+		from (select A.*, ROWNUM r from
+		(select * from notice
+		where notice_title like '%'||#{key}||'%'
+		order by notice_no) A
+		)
+		where r >= #{start} and
+		r &lt;= #{end}
+	</select>
+
+	<select id="getListWithContent" parameterType="map"
+		resultMap="noticeMap">
+		select *
+		from (select A.*, ROWNUM r from
+		(select * from notice where notice_content like '%'||#{key}||'%'
+		order by notice_no) A
+		)
+		where r >= #{start} and r &lt;= #{end}
+	</select>
+
+	<select id="getListWithRegDate" parameterType="map"
+		resultMap="noticeMap">
+		select *
+		from (select A.*, ROWNUM r from
+		(select * from notice where notice_regdate like '%'||#{key}||'%'
+		order by notice_no) A
+		)
+		where r >= #{start} and r &lt;= #{end}
+	</select>
+
+	<select id="get" parameterType="int" resultMap="noticeMap">
+		select * from
+		notice where notice_no = #{noticeNo}
+	</select>
 
 	<select id="getCount" resultType="Integer">
 		select count(*) from notice
 	</select>
-	
+
 	<insert id="add" parameterType="map">
-	insert into notice values ( notice_seq.nextVal , #{noticeTitle}, #{noticeContent}, sysdate)
+		insert into notice values (
+		notice_seq.nextVal , #{noticeTitle},
+		#{noticeContent}, sysdate)
 	</insert>
-	
+
 	<update id="set" parameterType="map">
-    update notice set notice_title = #{noticeTitle}, notice_content = #{noticeContent}, notice_regdate = sysdate 
-    where notice_no = #{noticeNo}
+		update notice set notice_title =
+		#{noticeTitle}, notice_content =
+		#{noticeContent}, notice_regdate =
+		sysdate
+		where notice_no = #{noticeNo}
 	</update>
-	
+
 	<delete id="remove" parameterType="int">
-	delete from notice where notice_no = #{noticeNo}
+		delete from notice where
+		notice_no = #{noticeNo}
 	</delete>
 </mapper>


### PR DESCRIPTION
# summary

공지 RESTful API의 페이지단위 읽기 요청에 쿼리 조건 넣는 기능 추가

# detail

- noticeTitle, noticeContent, noticeRegdate 각각에 대한 조건 검색 가능.
- 조건 검색은 key 텍스트의 포함여부로 이루어진다.
- API의 요청 파라미터로 페이지, opt, key가 주어지고, 해당 key값을 포함하는 opt컬럼을 가지는 레코드들 중에 해당 해당 페이지에 속하는 레코드들의 리스트를 반환한다.