### PR TITLE
관리자 공지&FAQ 페이지의 기본적인 조회 삭제기능 구현. 

### DIFF
--- a/WebContent/WEB-INF/views/admin/faq/index.jsp
+++ b/WebContent/WEB-INF/views/admin/faq/index.jsp
@@ -53,8 +53,9 @@ const getFaqList = (page)=>{
             contentType : "applicaton/json; charset=utf-8",
             success: (response)=> {//reponse는 count이다.
                 page = Math.min(response, page);//page가 전체 count보다 크면 count로 바꿔준다.
+                page = Math.max(page,1);//1보다 작을순 없다.
                 $("#faq-pagination").empty();
-                const pStart = Math.floor((page-1)/5)*5+1;//보여지는 pagination 시작점.
+                const pStart = Math.max(Math.floor((page-1)/5)*5+1,1);//보여지는 pagination 시작점.
                 $("#faq-pagination").append("<li class='page-item"+(pStart<6?" disabled":"")+"'><a class='page-link' href='javascript:getFaqList("+(pStart-1)+")'>&laquo;</a>");
                 for(let i = pStart; i<= Math.min(pStart+4,response) ; i++){
                      $("#faq-pagination").append("<li class='page-item"+(i==page?" active":"")+"'><a class='page-link' href='javascript:getFaqList("+i+")'>"+i+"</a></li>");
@@ -69,7 +70,8 @@ const getFaqList = (page)=>{
                     contentType : "applicaton/json; charset=utf-8",
                     success: (response)=> {
                         $("#faq-list").empty();
-                        for(idx in response){
+                        let idx = 0;
+                        for(; idx < response.length; idx++){
                             const faq = response[idx];
                             const day = ["일", "월", "화", "수", "목", "금", "토"];
                             const date = new Date(faq.faqRegDate)
@@ -81,7 +83,7 @@ const getFaqList = (page)=>{
                                     +date.getFullYear()+"년 "+padDate(date.getMonth()+1)+"월 "+padDate(date.getDate())+"일 ("+day[date.getDay()]+") "+padDate(date.getHours())+":"+padDate(date.getMinutes())+"</td><td>"
                                     +"<a  type='button' href='javascript:showModal("+faq.faqNo+")'><span class='badge rounded-pill bg-danger'>삭제</span></a></td></tr>");
                         }
-                        for(++idx ; idx<10; idx++){
+                        for(idx ; idx<10; idx++){
                             $("#faq-list").append("<tr rowspan='2'><th scope='row'>&nbsp;</th><td></td><td></td><td></td><td></td></tr>");
                         }
                     },

--- a/WebContent/WEB-INF/views/admin/notice/index.jsp
+++ b/WebContent/WEB-INF/views/admin/notice/index.jsp
@@ -54,8 +54,9 @@ const getNoticeList = (page)=>{
 	        contentType : "applicaton/json; charset=utf-8",
 	        success: (response)=> {//reponse는 count이다.
 	            page = Math.min(response, page);//page가 전체 count보다 크면 count로 바꿔준다.
+	            page = Math.max(page,1);//1보다 작을순 없다.
 	        	$("#notice-pagination").empty();
-	            const pStart = Math.floor((page-1)/5)*5+1;//보여지는 pagination 시작점.
+	            const pStart = Math.max(Math.floor((page-1)/5)*5+1,1);//보여지는 pagination 시작점.
 	            $("#notice-pagination").append("<li class='page-item"+(pStart<6?" disabled":"")+"'><a class='page-link' href='javascript:getNoticeList("+(pStart-1)+")'>&laquo;</a>");
 	            for(let i = pStart; i<= Math.min(pStart+4,response) ; i++){
 	                 $("#notice-pagination").append("<li class='page-item"+(i==page?" active":"")+"'><a class='page-link' href='javascript:getNoticeList("+i+")'>"+i+"</a></li>");
@@ -70,7 +71,8 @@ const getNoticeList = (page)=>{
 	                contentType : "applicaton/json; charset=utf-8",
 	                success: (response)=> {
 	                    $("#notice-list").empty();
-	                    for(idx in response){
+	                    let idx = 0;
+	                    for(; idx < response.length; idx++){
 	                        const notice = response[idx];
 	                        const day = ["일", "월", "화", "수", "목", "금", "토"];
 	                        const date = new Date(notice.noticeRegDate)
@@ -82,7 +84,7 @@ const getNoticeList = (page)=>{
 	                                +date.getFullYear()+"년 "+padDate(date.getMonth()+1)+"월 "+padDate(date.getDate())+"일 ("+day[date.getDay()]+") "+padDate(date.getHours())+":"+padDate(date.getMinutes())+"</td><td>"
 	                                +"<a  type='button' href='javascript:showModal("+notice.noticeNo+")'><span class='badge rounded-pill bg-danger'>삭제</span></a></td></tr>");
 	                    }
-	                    for(++idx ; idx<10; idx++){
+	                    for(idx ; idx<10; idx++){
 	                    	$("#notice-list").append("<tr rowspan='2'><th scope='row'>&nbsp;</th><td></td><td></td><td></td><td></td></tr>");
 	                    }
 	                },


### PR DESCRIPTION
# summary

관리자 공지&FAQ 페이지의 기본적인 조회 삭제기능 구현.  추가적으로 조건 검색 기능 추가해야함.

# detail

- [관리자 공지 메인 페이지 작성 조회 및 삭제 기능 완성](https://github.com/rkdgusrn1212/dz_proj2_team1/commit/bde79159f0ae09aab78fe2abe0e407d0be29c945)
- [FAQ index페이지(FAQ 메인 페이지) 구현완료](https://github.com/rkdgusrn1212/dz_proj2_team1/commit/5718e28cbfd8c1132a0034b5018284e31ab06e56)
- [faq, notice 메인에서 전체 페이지를 포함한 목록에 아예 아무것도 없을때 테이블 자체가 소멸하는 버그수정](https://github.com/rkdgusrn1212/dz_proj2_team1/commit/8ac94f3c069f66fa9e57d7eb4579a2ae11e9c7ef)