### PR TITLE
Qna 테이블 스키마 변경

### DIFF
--- a/src/main/resources/db/QNA.sql
+++ b/src/main/resources/db/QNA.sql
@@ -1,16 +1,14 @@
 CREATE TABLE QNA( -- 고객센터 QnA 테이블
-    QNA_NO       		NUMBER  	NOT NULL	PRIMARY KEY,	-- 문의 번호 (100번부터 시작 1씩 증가)
-    QNA_TITLE    		VARCHAR2(64)	NOT NULL,			-- 문의 제목
-    QNA_CONTENT 	VARCHAR2(512)	NOT NULL,			-- 문의 내용
-    QNA_REGDATE  	DATE		NOT NULL,			-- 작성일
-    QNA_WRITER  		NUMBER,						-- 회원 작성자	FK ( MEMBER 테이블 PK 참조 )
-    QNA_NONMEMBER	VARCHAR2(64),					-- 비회원 작성자
-    QNA_PWD		VARCHAR2(64)	NOT NULL,			-- 비회원 작성시 비밀번호
-    QNA_PUBLIC		BOOLEAN	DEFAULT 0,			-- 공개여부 (기본값 0 비공개)
-    QNA_REPLY		VARCHAR2(512)					-- 답글
-    CONSTRAINT 	
-    FK_SERVICE FOREIGN KEY(QNA_WRITER) REFERENCES MEMBER(MEMBER_NO) ON DELETE CASCADE
+    QNA_NO          NUMBER  	    NOT NULL        PRIMARY KEY,	    -- 문의 번호 (100번부터 시작 1씩 증가)
+    QNA_TITLE    	NVARCHAR2(60)	NOT NULL,       -- 문의 제목
+    QNA_CONTENT 	NVARCHAR2(1000)   NOT NULL,	    -- 문의 내용
+    QNA_REGDATE  	DATE            NOT NULL,		-- 작성일
+    QNA_WRITER      NUMBER,						    -- 회원 작성자	FK ( MEMBER 테이블 PK 참조 )
+    QNA_NONMEMBER   NVARCHAR2(64),					-- 비회원 작성자
+    QNA_PWD	        CHAR(60)    NOT NULL,           -- 암호화된 비밀번호 무조건 60자
+    QNA_PUBLIC      CHAR(1)	        DEFAULT 'T',    -- 공개여부 (기본값 T 비공개)
+    QNA_REPLY	    NVARCHAR2(1000)	                -- 답글
+    CONSTRAINT FK_SERVICE FOREIGN KEY(QNA_WRITER) REFERENCES MEMBER(MEMBER_NO) ON DELETE CASCADE
 );
 
 CREATE SEQUENCE QNA_SEQ START WITH 100 INCREMENT BY 1 NOCYCLE;
-SELECT*FROM SERVICE;


### PR DESCRIPTION
# summary

Qna 테이블 스키마 변경, 테이블 작성의 표준으로 이 후에 다른 테이블도 같은 규칙을 반영해야함.

# detail

- boolean 타입 대신 CHAR(1)
- *title은 60자로 제한, 뷰에서 그 이상은 띄울일 없으므로 사용자에게 해당 크기로 제한을 줌.
- *content는 1000자로 제한, 뷰에서 그 이상은 띄울일 없으므로 사용자에게 해당 크기로 제한을 줌.
- 한글도 같이 저장되는 컬럼은 NVARCHAR로 변환.
- 비밀번호는 무조건 CHAR(60)으로, 비밀번호 해싱값의 크기다.